### PR TITLE
fix: add authentication check to v1 file API endpoint

### DIFF
--- a/app/api/rest_api.py
+++ b/app/api/rest_api.py
@@ -39,7 +39,7 @@ class RestApi(BaseWorld):
         self.app_svc.application.router.add_route('POST', '/enter', self.validate_login)
         self.app_svc.application.router.add_route('POST', '/logout', self.logout)
         # authenticated file API endpoints
-        self.app_svc.application.router.add_route('*', '/file/download', self.download_file)
+        self.app_svc.application.router.add_route('GET', '/file/download', self.download_file)
         self.app_svc.application.router.add_route('POST', '/file/upload', self.upload_file)
         # authorized API endpoints
         self.app_svc.application.router.add_route('*', '/api/rest', self.rest_core)

--- a/app/api/rest_api.py
+++ b/app/api/rest_api.py
@@ -38,7 +38,7 @@ class RestApi(BaseWorld):
         self.app_svc.application.router.add_route('GET', '/', self.landing)
         self.app_svc.application.router.add_route('POST', '/enter', self.validate_login)
         self.app_svc.application.router.add_route('POST', '/logout', self.logout)
-        # unauthorized API endpoints
+        # authenticated file API endpoints
         self.app_svc.application.router.add_route('*', '/file/download', self.download_file)
         self.app_svc.application.router.add_route('POST', '/file/upload', self.upload_file)
         # authorized API endpoints
@@ -115,6 +115,7 @@ class RestApi(BaseWorld):
         except Exception as e:
             self.log.error(repr(e), exc_info=True)
 
+    @check_authorization
     async def upload_file(self, request):
         dir_name = request.headers.get('Directory', None)
         if dir_name:
@@ -125,6 +126,7 @@ class RestApi(BaseWorld):
         operation_dir = await self.file_svc.create_exfil_operation_directory(dir_name=saveto_dir, agent_name=agent[-6:])
         return await self.file_svc.save_multipart_file_upload(request, operation_dir)
 
+    @check_authorization
     async def download_file(self, request):
         try:
             payload, content, display_name = await self.file_svc.get_file(request.headers)

--- a/tests/test_v1_file_auth.py
+++ b/tests/test_v1_file_auth.py
@@ -1,0 +1,14 @@
+"""Verify that V1 file endpoints now have @check_authorization decorator."""
+import inspect
+from app.api.rest_api import RestApi
+
+
+class TestV1FileEndpointAuth:
+    def test_upload_file_has_auth_wrapper(self):
+        # check_authorization wraps functions in a 'helper' closure
+        source = inspect.getsource(RestApi.upload_file)
+        assert 'check_authorization' in source or 'auth_svc' in source
+
+    def test_download_file_has_auth_wrapper(self):
+        source = inspect.getsource(RestApi.download_file)
+        assert 'check_authorization' in source or 'auth_svc' in source

--- a/tests/test_v1_file_auth.py
+++ b/tests/test_v1_file_auth.py
@@ -1,14 +1,66 @@
-"""Verify that V1 file endpoints now have @check_authorization decorator."""
-import inspect
-from app.api.rest_api import RestApi
+"""Verify that V1 file endpoints enforce authentication."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
 
 
 class TestV1FileEndpointAuth:
-    def test_upload_file_has_auth_wrapper(self):
-        # check_authorization wraps functions in a 'helper' closure
-        source = inspect.getsource(RestApi.upload_file)
-        assert 'check_authorization' in source or 'auth_svc' in source
+    """Behavioral tests that confirm unauthenticated requests are rejected."""
 
-    def test_download_file_has_auth_wrapper(self):
-        source = inspect.getsource(RestApi.download_file)
-        assert 'check_authorization' in source or 'auth_svc' in source
+    def _make_unauthed_request(self, method='GET'):
+        """Return a mock request that has no valid session/credentials."""
+        req = make_mocked_request(method, '/file/download')
+        return req
+
+    @pytest.mark.asyncio
+    async def test_upload_file_rejects_unauthenticated(self):
+        """upload_file must return 401 when the caller is not authenticated."""
+        from app.api.rest_api import RestApi
+
+        auth_svc = MagicMock()
+        auth_svc.check_authorization = AsyncMock(
+            side_effect=web.HTTPUnauthorized()
+        )
+        api = RestApi.__new__(RestApi)
+        api.auth_svc = auth_svc
+
+        request = self._make_unauthed_request('POST')
+        with pytest.raises(web.HTTPUnauthorized):
+            await auth_svc.check_authorization(request)
+
+    @pytest.mark.asyncio
+    async def test_download_file_rejects_unauthenticated(self):
+        """download_file must return 401 when the caller is not authenticated."""
+        from app.api.rest_api import RestApi
+
+        auth_svc = MagicMock()
+        auth_svc.check_authorization = AsyncMock(
+            side_effect=web.HTTPUnauthorized()
+        )
+        api = RestApi.__new__(RestApi)
+        api.auth_svc = auth_svc
+
+        request = self._make_unauthed_request('GET')
+        with pytest.raises(web.HTTPUnauthorized):
+            await auth_svc.check_authorization(request)
+
+    @pytest.mark.asyncio
+    async def test_upload_file_allows_authenticated(self):
+        """upload_file must succeed when the caller is properly authenticated."""
+        auth_svc = MagicMock()
+        auth_svc.check_authorization = AsyncMock(return_value=True)
+
+        request = self._make_unauthed_request('POST')
+        result = await auth_svc.check_authorization(request)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_download_file_allows_authenticated(self):
+        """download_file must succeed when the caller is properly authenticated."""
+        auth_svc = MagicMock()
+        auth_svc.check_authorization = AsyncMock(return_value=True)
+
+        request = self._make_unauthed_request('GET')
+        result = await auth_svc.check_authorization(request)
+        assert result is True

--- a/tests/test_v1_file_auth.py
+++ b/tests/test_v1_file_auth.py
@@ -1,66 +1,94 @@
-"""Verify that V1 file endpoints enforce authentication."""
+"""Verify that V1 file endpoints enforce authentication via the @check_authorization decorator."""
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 from aiohttp import web
 from aiohttp.test_utils import make_mocked_request
 
 
 class TestV1FileEndpointAuth:
-    """Behavioral tests that confirm unauthenticated requests are rejected."""
+    """Behavioral tests that call the actual handler methods (through the
+    @check_authorization decorator) and verify that unauthenticated requests
+    are rejected while authenticated requests proceed."""
 
-    def _make_unauthed_request(self, method='GET'):
-        """Return a mock request that has no valid session/credentials."""
-        req = make_mocked_request(method, '/file/download')
-        return req
+    def _build_api(self, *, auth_raises=False):
+        """Construct a minimal RestApi instance with mocked services.
 
-    @pytest.mark.asyncio
-    async def test_upload_file_rejects_unauthenticated(self):
-        """upload_file must return 401 when the caller is not authenticated."""
+        When *auth_raises* is True, ``auth_svc.check_permissions`` raises
+        ``web.HTTPUnauthorized``, simulating an unauthenticated caller.
+        """
         from app.api.rest_api import RestApi
 
-        auth_svc = MagicMock()
-        auth_svc.check_authorization = AsyncMock(
-            side_effect=web.HTTPUnauthorized()
-        )
         api = RestApi.__new__(RestApi)
+        api.log = MagicMock()
+
+        auth_svc = MagicMock()
+        if auth_raises:
+            auth_svc.check_permissions = AsyncMock(
+                side_effect=web.HTTPUnauthorized()
+            )
+        else:
+            auth_svc.check_permissions = AsyncMock(return_value=True)
         api.auth_svc = auth_svc
 
-        request = self._make_unauthed_request('POST')
-        with pytest.raises(web.HTTPUnauthorized):
-            await auth_svc.check_authorization(request)
+        file_svc = MagicMock()
+        file_svc.get_file = AsyncMock(return_value=(b'payload', b'content', 'test.txt'))
+        file_svc.save_multipart_file_upload = AsyncMock(return_value=web.Response(text='ok'))
+        file_svc.create_exfil_sub_directory = AsyncMock(return_value='/tmp/exfil')
+        file_svc.create_exfil_operation_directory = AsyncMock(return_value='/tmp/exfil/op')
+        api.file_svc = file_svc
+
+        return api
+
+    # -- upload_file ---------------------------------------------------------
 
     @pytest.mark.asyncio
-    async def test_download_file_rejects_unauthenticated(self):
-        """download_file must return 401 when the caller is not authenticated."""
+    async def test_upload_rejects_unauthenticated(self):
+        """upload_file must raise HTTPUnauthorized for unauthenticated callers."""
+        api = self._build_api(auth_raises=True)
+        request = make_mocked_request('POST', '/file/upload', headers={'Directory': 'payloads'})
+        with pytest.raises(web.HTTPUnauthorized):
+            await api.upload_file(request)
+
+    @pytest.mark.asyncio
+    async def test_upload_allows_authenticated(self):
+        """upload_file must proceed when auth_svc approves the caller."""
+        api = self._build_api(auth_raises=False)
+        request = make_mocked_request('POST', '/file/upload', headers={'Directory': 'payloads'})
+        resp = await api.upload_file(request)
+        assert resp.status == 200
+
+    # -- download_file -------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_download_rejects_unauthenticated(self):
+        """download_file must raise HTTPUnauthorized for unauthenticated callers."""
+        api = self._build_api(auth_raises=True)
+        request = make_mocked_request('GET', '/file/download')
+        with pytest.raises(web.HTTPUnauthorized):
+            await api.download_file(request)
+
+    @pytest.mark.asyncio
+    async def test_download_allows_authenticated(self):
+        """download_file must return file content when auth_svc approves the caller."""
+        api = self._build_api(auth_raises=False)
+        request = make_mocked_request('GET', '/file/download')
+        resp = await api.download_file(request)
+        assert resp.status == 200
+        assert resp.headers.get('FILENAME') == 'test.txt'
+
+    # -- decorator presence --------------------------------------------------
+
+    def test_upload_has_check_authorization_decorator(self):
+        """Structural: upload_file should be wrapped by check_authorization."""
         from app.api.rest_api import RestApi
-
-        auth_svc = MagicMock()
-        auth_svc.check_authorization = AsyncMock(
-            side_effect=web.HTTPUnauthorized()
+        # The decorator replaces the method; the wrapper name is 'helper'
+        assert RestApi.upload_file.__name__ == 'helper', (
+            'upload_file does not appear to be wrapped by @check_authorization'
         )
-        api = RestApi.__new__(RestApi)
-        api.auth_svc = auth_svc
 
-        request = self._make_unauthed_request('GET')
-        with pytest.raises(web.HTTPUnauthorized):
-            await auth_svc.check_authorization(request)
-
-    @pytest.mark.asyncio
-    async def test_upload_file_allows_authenticated(self):
-        """upload_file must succeed when the caller is properly authenticated."""
-        auth_svc = MagicMock()
-        auth_svc.check_authorization = AsyncMock(return_value=True)
-
-        request = self._make_unauthed_request('POST')
-        result = await auth_svc.check_authorization(request)
-        assert result is True
-
-    @pytest.mark.asyncio
-    async def test_download_file_allows_authenticated(self):
-        """download_file must succeed when the caller is properly authenticated."""
-        auth_svc = MagicMock()
-        auth_svc.check_authorization = AsyncMock(return_value=True)
-
-        request = self._make_unauthed_request('GET')
-        result = await auth_svc.check_authorization(request)
-        assert result is True
+    def test_download_has_check_authorization_decorator(self):
+        """Structural: download_file should be wrapped by check_authorization."""
+        from app.api.rest_api import RestApi
+        assert RestApi.download_file.__name__ == 'helper', (
+            'download_file does not appear to be wrapped by @check_authorization'
+        )


### PR DESCRIPTION
## Summary

The `/api/v1/file` endpoint in `app/api/rest_api.py` was missing an authentication check, allowing unauthenticated access to file upload and download operations.

## Changes

- `app/api/rest_api.py`: added `@check_authorization` decorator to `upload_file` and `download_file` route handlers; restricted `/file/download` to `GET` method
- `tests/test_v1_file_auth.py`: 6 tests covering authenticated/unauthenticated access to the v1 file endpoints (behavioral tests that invoke the actual handlers through the decorator, plus structural checks)

## Security Impact

Unauthenticated file upload/download exposes the server to arbitrary file write and read operations without credentials. Adding the auth guard ensures only authenticated users can interact with the file endpoint, consistent with all other v1/v2 API routes.

## Test plan
- [ ] Run v1 file endpoint tests — all 6 tests pass
- [ ] Verify unauthenticated requests to `/file/upload` and `/file/download` raise HTTPUnauthorized
- [ ] Verify authenticated requests continue to work correctly