### PR TITLE
build(deps): bump aiohttp, cryptography, and asyncssh for security advisories

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 aiohttp-jinja2==1.5.1
-aiohttp==3.14.1
+aiohttp==3.14.3
 aiohttp_session==2.12.0
 aiohttp-security==0.4.0
 aiohttp-apispec==3.0.0b2
 argon2-cffi==25.1.0
 jinja2==3.1.6
 pyyaml==6.0.1
-cryptography==48.0.1
+cryptography==50.0.1
 websockets==15.0
 Sphinx==7.1.2
 sphinx_rtd_theme==1.3.0
@@ -22,7 +22,7 @@ lxml==6.1.0  # debrief
 svglib==1.5.1  # debrief
 Markdown==3.8.1  # training
 dnspython==2.6.1
-asyncssh==2.20.0
+asyncssh==2.23.1
 aioftp==0.27.2
 packaging==23.2
 croniter~=3.0.3


### PR DESCRIPTION
## Description

Bumps three dependencies flagged by `pip-audit` in the `safety` tox env:

- `aiohttp` 3.14.1 -> 3.14.3 (PYSEC-2026-3545/3546/3547)
- `cryptography` 48.0.1 -> 50.0.1 (PYSEC-2026-3552/3553/3554)
- `asyncssh` 2.20.0 -> 2.23.1 (CVE-2026-54591)

Supersedes #3405 (aiohttp) and #3406 (cryptography). The `asyncssh`
advisory has no Dependabot PR yet and `safety` fails on master without it,
so all three are bumped together; neither open PR passes CI on its own.

All three require Python >= 3.10, so the full test matrix is unaffected.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Full suite run before and after the bump, on Python 3.13 and 3.11:

- `pytest --asyncio-mode=auto tests` - 562 passed on both, identical to the
  pre-bump baseline, with no new warnings
- `pip-audit -r requirements.txt` - no known vulnerabilities (was 4)
- `pip-audit -r requirements-dev.txt` - no known vulnerabilities
- `bandit -r app -ll --skip=B303` - pass, 16 low / 0 medium / 0 high

The `asyncssh` bump is exercised end-to-end by
`tests/contacts/test_ssh_tunneling.py`, which starts the real tunnel server,
authenticates a client, and forwards a local port.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (n/a)
- [x] I have added tests that prove my fix is effective (existing coverage
      exercises all three packages; no new tests needed)
