### PR TITLE
Change notification emails in .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -10,10 +10,10 @@
 # later if dev@ gets too noisy).
 notifications:
   commits:      commits@caldera.apache.org
-  issues:       dev@caldera.apache.org
-  pullrequests: dev@caldera.apache.org
-  # jobs: dev@caldera.apache.org        # GitHub Actions build status — enable if the project wants CI failures on-list
-  # jira_options: link label comment    # only if Caldera adopts ASF Jira; it uses GitHub Issues, so omitted
+  issues:       notifications@caldera.apache.org
+  pullrequests: notifications@caldera.apache.org
+  jobs:         notifications@caldera.apache.org
+  discussions:  notifications@caldera.apache.org  
   
 # --- RECOMMENDED: repo metadata, features, and merge policy ----------------------------------------
 github:


### PR DESCRIPTION
Currently, the .asf.yaml is causing automation issues because you discussions enabled but don't have a mailing list set up for them.
I also moved the GitHub traffic to notifications@caldera.a.o because it is very useful to keep dev mailing list focused on dev discussions and not buried in GitHub notifications.