### PR TITLE
Build Docker images on tag pushes

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -1,9 +1,9 @@
 name: Create and publish a Docker image
 
 on:
-  release:
-    types: [published]
-  workflow_dispatch:
+  push:
+    tags:
+      - '**'
 
 permissions:
   contents: read
@@ -37,11 +37,10 @@ jobs:
         uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          flavor: |
-            latest=auto
-            prefix=slim-,onlatest=true
-            suffix=
-        
+          tags: |
+            type=ref,event=tag,prefix=slim-
+            type=raw,value=slim-latest
+
       - name: Build and push Docker image (slim)
         uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825
         with:
@@ -51,12 +50,15 @@ jobs:
           labels: ${{ steps.meta-slim.outputs.labels }}
           build-args: |
             VARIANT=slim
-      
+
       - name: Extract metadata (tags, labels) for Docker (full variant)
         id: meta-full
         uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest
 
       - name: Build and push Docker image (full)
         uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825


### PR DESCRIPTION
## Description

Make docker workflow run automatically on tag pushes.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I pushed a tag to my branch, the workflow correctly triggered and published an appropriately-named image: https://github.com/0xd6cb6d73/caldera/pkgs/container/caldera/1196333212?tag=test123.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
